### PR TITLE
fix(ha): catalog resolution, orphan safety, client-proxy TLS

### DIFF
--- a/nomad/deploy/api-deploy.hcl
+++ b/nomad/deploy/api-deploy.hcl
@@ -1,0 +1,111 @@
+job "api" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  node_pool = "api"
+  priority = 90
+
+  group "api-service" {
+    count = 2
+
+    network {
+      port "api" {
+        static = "50001"
+      }
+    }
+
+    constraint {
+      operator  = "distinct_hosts"
+      value     = "true"
+    }
+
+    service {
+      name = "api"
+      port = "50001"
+      task = "start"
+
+      check {
+        type     = "http"
+        name     = "health"
+        path     = "/health"
+        interval = "3s"
+        timeout  = "3s"
+        port     = "50001"
+      }
+    }
+
+
+
+    task "start" {
+      driver       = "docker"
+      # If we need more than 30s we will need to update the max_kill_timeout in nomad
+      # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
+      kill_timeout = "30s"
+      kill_signal  = "SIGTERM"
+
+      resources {
+        memory_max = 32768
+        memory     = 32768
+        cpu        = 8000
+      }
+
+      env {
+        ORCHESTRATOR_PORT             = 5008
+        TEMPLATE_MANAGER_HOST         = "template-manager.service.consul:5009"
+        AWS_ENABLED                   = "true"
+        AWS_DOCKER_REPOSITORY_NAME    = "e2bdev/base"
+        AWS_REGION                   = "us-west-2"
+        CLICKHOUSE_CONNECTION_STRING   = ""
+        CLICKHOUSE_USERNAME            = ""
+        CLICKHOUSE_PASSWORD            = ""
+        CLICKHOUSE_DATABASE            = ""
+        ENVIRONMENT                   = "dev"
+        POSTHOG_API_KEY               = "posthog_api_key"
+        ANALYTICS_COLLECTOR_HOST      = ""
+        ANALYTICS_COLLECTOR_API_TOKEN = ""
+        LOKI_ADDRESS                  = "http://loki.service.consul:3100"
+        OTEL_TRACING_PRINT            = "false"
+        LOGS_COLLECTOR_ADDRESS        = "http://localhost:30006"
+        NOMAD_ADDRESS                 = "https://localhost:4646"
+        NOMAD_CACERT                  = "/opt/nomad/tls/ca.pem"
+        NOMAD_CLIENT_CERT             = "/opt/nomad/tls/cert.pem"
+        NOMAD_CLIENT_KEY              = "/opt/nomad/tls/key.pem"
+        OTEL_COLLECTOR_GRPC_ENDPOINT  = "localhost:4317"
+        REDIS_URL                     = "e2b-dev-redis-s2auw3.serverless.usw2.cache.amazonaws.com:6379"
+        SANDBOX_STORAGE_BACKEND       = "redis"
+        DNS_PORT                      = 5353
+        # This is here just because it is required in some part of our code which is transitively imported
+        TEMPLATE_BUCKET_NAME          = "skip"
+        BUILD_CONTEXT_BUCKET_NAME     = "e2b-dev-docker-contexts-269562551342"
+      }
+
+      template {
+        data = <<EOH
+POSTGRES_CONNECTION_STRING={{ file "/opt/e2b/secrets/postgres_connection_string" }}
+DB_HOST={{ file "/opt/e2b/secrets/postgres_host" }}
+DB_USER={{ file "/opt/e2b/secrets/postgres_user" }}
+DB_PASSWORD={{ file "/opt/e2b/secrets/postgres_password" }}
+NOMAD_TOKEN={{ file "/opt/e2b/secrets/nomad_acl_token" }}
+CONSUL_HTTP_TOKEN={{ file "/opt/e2b/secrets/consul_http_token" }}
+ADMIN_TOKEN={{ file "/opt/e2b/secrets/admin_token" }}
+SANDBOX_ACCESS_TOKEN_HASH_SEED={{ file "/opt/e2b/secrets/sandbox_access_token_hash_seed" }}
+EOH
+        destination = "secrets/secrets.env"
+        env         = true
+        change_mode = "restart"
+        perms       = "400"
+      }
+
+      config {
+        network_mode = "host"
+        dns_servers  = ["127.0.0.53"]
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/api:17aaf96"
+        ports        = ["api"]
+        args         = [
+          "--port", "50001",
+        ]
+        volumes = [
+          "/opt/nomad/tls:/opt/nomad/tls:ro"
+        ]
+      }
+    }
+  }
+}

--- a/nomad/deploy/api-deploy.hcl
+++ b/nomad/deploy/api-deploy.hcl
@@ -97,7 +97,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/api:c4ca593"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/api:4fdbdf7"
         ports        = ["api"]
         args         = [
           "--port", "50001",

--- a/nomad/deploy/api-deploy.hcl
+++ b/nomad/deploy/api-deploy.hcl
@@ -97,7 +97,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/api:17aaf96"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/api:c4ca593"
         ports        = ["api"]
         args         = [
           "--port", "50001",

--- a/nomad/deploy/docker-reverse-proxy-deploy.hcl
+++ b/nomad/deploy/docker-reverse-proxy-deploy.hcl
@@ -1,0 +1,73 @@
+job "docker-reverse-proxy" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  node_pool = "api"
+  priority = 85
+
+  group "docker-reverse-proxy" {
+    network {
+      port "docker-reverse-proxy" {
+        static = "5000"
+      }
+    }
+
+    service {
+      name = "docker-reverse-proxy"
+      port = "docker-reverse-proxy"
+      task = "start"
+
+      check {
+        type     = "http"
+        name     = "health"
+        path     = "/health"
+        interval = "5s"
+        timeout  = "5s"
+        port     = "docker-reverse-proxy"
+      }
+    }
+
+    task "start" {
+      driver = "docker"
+
+      resources {
+        memory_max = 2048
+        memory = 512
+        cpu    = 256
+      }
+
+      env {
+        # POSTGRES_CONNECTION_STRING = "postgresql://e2badmin@e2b-dev-e2b-aurora-db.cluster-cldxbe3nbhn3.us-west-2.rds.amazonaws.com/e2b"
+        # CFNDBURL = "postgresql://e2badmin@e2b-dev-e2b-aurora-db.cluster-cldxbe3nbhn3.us-west-2.rds.amazonaws.com/e2b"
+        # AWS_REGION                 = "us-west-2"
+        # AWS_ACCOUNT_ID             = "269562551342"
+        # AWS_ECR_REPOSITORY         = "e2bdev/base"
+        # DOMAIN_NAME                = "e2b-dev.internal"
+        # LOG_LEVEL                  = "debug"
+
+        CLOUD_PROVIDER             =   "aws"
+        DOMAIN_NAME                = "e2b-dev.internal"
+        AWS_REGION                 = "us-west-2"
+        AWS_ECR_REPOSITORY_NAME    = "e2bdev/base"
+        LOG_LEVEL                  = "debug"
+      }
+
+      template {
+        data = <<EOH
+POSTGRES_CONNECTION_STRING={{ file "/opt/e2b/secrets/postgres_connection_string" }}
+EOH
+        destination = "secrets/secrets.env"
+        env         = true
+        change_mode = "restart"
+        perms       = "400"
+      }
+
+      config {
+        network_mode = "host"
+        dns_servers  = ["127.0.0.53"]
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/docker-reverse-proxy:76ea90d"
+        ports        = ["docker-reverse-proxy"]
+        args         = ["--port", "5000"]
+        force_pull   = true
+      }
+    }
+  }
+}

--- a/nomad/deploy/docker-reverse-proxy-deploy.hcl
+++ b/nomad/deploy/docker-reverse-proxy-deploy.hcl
@@ -63,7 +63,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/docker-reverse-proxy:c4ca593"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/docker-reverse-proxy:4fdbdf7"
         ports        = ["docker-reverse-proxy"]
         args         = ["--port", "5000"]
         force_pull   = true

--- a/nomad/deploy/docker-reverse-proxy-deploy.hcl
+++ b/nomad/deploy/docker-reverse-proxy-deploy.hcl
@@ -63,7 +63,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/docker-reverse-proxy:76ea90d"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/docker-reverse-proxy:c4ca593"
         ports        = ["docker-reverse-proxy"]
         args         = ["--port", "5000"]
         force_pull   = true

--- a/nomad/deploy/edge-deploy.hcl
+++ b/nomad/deploy/edge-deploy.hcl
@@ -102,7 +102,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/client-proxy:c4ca593"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/client-proxy:4fdbdf7"
         ports        = ["session", "edge-api"]
       }
     }

--- a/nomad/deploy/edge-deploy.hcl
+++ b/nomad/deploy/edge-deploy.hcl
@@ -1,11 +1,11 @@
 job "client-proxy" {
-  datacenters = ["${aws_az1}", "${aws_az2}"]
+  datacenters = ["us-west-2a", "us-west-2b"]
   node_pool = "api"
 
   priority = 80
 
   group "client-proxy" {
-    count = ${CLIENT_PROXY_COUNT}
+    count = 2
 
     constraint {
       operator  = "distinct_hosts"
@@ -81,11 +81,11 @@ job "client-proxy" {
         ENVIRONMENT = "dev"
 
         // use legacy dns resolution for orchestrator services
-        USE_CATALOG_RESOLUTION = "true"
+        USE_PROXY_CATALOG_RESOLUTION = "true"
 
         OTEL_COLLECTOR_GRPC_ENDPOINT  = "localhost:4317"
         LOGS_COLLECTOR_ADDRESS        = "analytics_collector_host"
-        REDIS_URL                     = "${REDIS_ENDPOINT}:6379"
+        REDIS_URL                     = "e2b-dev-redis-s2auw3.serverless.usw2.cache.amazonaws.com:6379"
         LOKI_URL                      = "http://loki.service.consul:3100"
       }
 
@@ -102,7 +102,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "${account_id}.dkr.ecr.${AWSREGION}.amazonaws.com/e2b-orchestration/client-proxy:${IMAGE_TAG}"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/client-proxy:76ea90d"
         ports        = ["session", "edge-api"]
       }
     }

--- a/nomad/deploy/edge-deploy.hcl
+++ b/nomad/deploy/edge-deploy.hcl
@@ -81,7 +81,7 @@ job "client-proxy" {
         ENVIRONMENT = "dev"
 
         // use legacy dns resolution for orchestrator services
-        USE_PROXY_CATALOG_RESOLUTION = "true"
+        USE_CATALOG_RESOLUTION = "true"
 
         OTEL_COLLECTOR_GRPC_ENDPOINT  = "localhost:4317"
         LOGS_COLLECTOR_ADDRESS        = "analytics_collector_host"
@@ -102,7 +102,7 @@ EOH
       config {
         network_mode = "host"
         dns_servers  = ["127.0.0.53"]
-        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/client-proxy:76ea90d"
+        image        = "269562551342.dkr.ecr.us-west-2.amazonaws.com/e2b-orchestration/client-proxy:c4ca593"
         ports        = ["session", "edge-api"]
       }
     }

--- a/nomad/deploy/logs-collector-deploy.hcl
+++ b/nomad/deploy/logs-collector-deploy.hcl
@@ -1,0 +1,256 @@
+job "logs-collector" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  type        = "system"
+  node_pool    = "all"
+
+  priority = 85
+
+  group "logs-collector" {
+    network {
+      port "health" {
+        to = 44313
+      }
+      port "logs" {
+        to = 30006
+      }
+    }
+
+    service {
+      name = "logs-collector"
+      port = "logs"
+      tags = [
+        "logs",
+        "health",
+      ]
+
+      check {
+        type     = "http"
+        name     = "health"
+        path     = "/health"
+        interval = "20s"
+        timeout  = "5s"
+        port     = 44313
+      }
+    }
+
+    task "start-collector" {
+      driver = "docker"
+
+      config {
+        network_mode = "host"
+        image        = "artifactory.aic.aws.zoomdev.us/zoom-docker-virtual/timberio/vector:0.44.0-alpine"
+        auth_soft_fail = true
+        ports = [
+          "health",
+          "logs",
+        ]
+      }
+
+      env {
+        VECTOR_CONFIG          = "local/vector.toml"
+        VECTOR_REQUIRE_HEALTHY = "true"
+        VECTOR_LOG             = "warn"
+      }
+
+      resources {
+        memory_max = 4096
+        memory     = 512
+        cpu        = 500
+      }
+
+      template {
+        destination   = "local/vector.toml"
+        change_mode   = "signal"
+        change_signal = "SIGHUP"
+        # overriding the delimiters to [[ ]] to avoid conflicts with Vector's native templating, which also uses {{ }}
+        left_delimiter  = "[["
+        right_delimiter = "]]"
+        data            = <<EOH
+data_dir = "alloc/data/vector/"
+
+[api]
+enabled = true
+address = "0.0.0.0:44313"
+
+[sources.http_server]
+type = "http_server"
+address = "0.0.0.0:30006"
+encoding = "ndjson"
+path_key = "_path"
+
+[transforms.add_source_http_server]
+type = "remap"
+inputs = ["http_server"]
+source = """
+del(."_path")
+.sandboxID = .instanceID
+.timestamp = parse_timestamp(.timestamp, format: "%+") ?? now()
+# Normalize keys
+if exists(.sandbox_id) {
+  .sandboxID = .sandbox_id
+}
+if exists(.build_id) {
+  .buildID = .build_id
+}
+if exists(.env_id) {
+  .envID = .env_id
+}
+if exists(.team_id) {
+  .teamID = .team_id
+}
+if exists(."template.id") {
+  .templateID = ."template.id"
+  del(."template.id")
+}
+if exists(."sandbox.id") {
+  .sandboxID = ."sandbox.id"
+  del(."sandbox.id")
+}
+if exists(."build.id") {
+  .buildID = ."build.id"
+  del(."build.id")
+}
+if exists(."env.id") {
+  .envID = ."env.id"
+  del(."env.id")
+}
+if exists(."team.id") {
+  .teamID = ."team.id"
+  del(."team.id")
+}
+
+# Apply defaults if not already set
+if !exists(.envID) {
+  .envID = "unknown"
+}
+if !exists(.category) {
+  .category = "default"
+}
+if !exists(.teamID) {
+  .teamID = "unknown"
+}
+if !exists(.sandboxID) {
+  .sandboxID = "unknown"
+}
+if !exists(.buildID) {
+  .buildID = "unknown"
+}
+if !exists(.service) {
+  .service = "envd"
+}
+"""
+
+[transforms.internal_routing]
+type = "route"
+inputs = [ "add_source_http_server" ]
+
+[transforms.internal_routing.route]
+internal = '.internal == true'
+
+[transforms.remove_internal]
+type = "remap"
+inputs = [ "internal_routing._unmatched" ]
+source = '''
+del(.internal)
+'''
+
+[transforms.to_otel_logs]
+type = "remap"
+inputs = [ "remove_internal" ]
+source = '''
+severity_text = if .level == "debug" {
+  "DEBUG"
+} else if .level == "info" {
+  "INFO"
+} else if .level == "warn" {
+  "WARN"
+} else if .level == "error" {
+  "ERROR"
+} else if .level == "dpanic" {
+  "ERROR"
+} else if .level == "panic" {
+  "FATAL"
+} else if .level == "fatal" {
+  "FATAL"
+} else {
+  upcase(to_string(.level) ?? "INFO")
+}
+
+logger_name = to_string(.logger) ?? "sandbox"
+trace_id = if exists(.traceID) { to_string(.traceID) ?? "" } else { "" }
+template_id = if exists(.templateID) { to_string(.templateID) ?? "" } else { "" }
+stacktrace = if exists(.stacktrace) { to_string(.stacktrace) ?? "" } else { "" }
+event_type = if exists(.event_type) { to_string(.event_type) ?? "" } else { "" }
+operation_id = if exists(.operation_id) { to_string(.operation_id) ?? "" } else { "" }
+data = if exists(.data) { to_string(.data) ?? "" } else { "" }
+message = if data != "" && (event_type == "stdout" || event_type == "stderr") {
+  data
+} else {
+  to_string(.message) ?? ""
+}
+
+. = {
+  "resourceLogs": [{
+    "resource": {
+      "attributes": [
+        { "key": "service.name", "value": { "stringValue": to_string(.service) ?? "envd" } },
+        { "key": "e2b.team_id", "value": { "stringValue": to_string(.teamID) ?? "unknown" } },
+        { "key": "e2b.env_id", "value": { "stringValue": to_string(.envID) ?? "unknown" } },
+        { "key": "e2b.build_id", "value": { "stringValue": to_string(.buildID) ?? "unknown" } },
+        { "key": "e2b.sandbox_id", "value": { "stringValue": to_string(.sandboxID) ?? "unknown" } },
+        { "key": "e2b.category", "value": { "stringValue": to_string(.category) ?? "default" } }
+      ]
+    },
+    "scopeLogs": [{
+      "scope": {
+        "name": logger_name
+      },
+      "logRecords": [{
+        "timeUnixNano": to_unix_timestamp!(.timestamp, unit: "nanoseconds"),
+        "body": { "stringValue": message },
+        "severityText": severity_text,
+        "attributes": [
+          { "key": "logger", "value": { "stringValue": logger_name } },
+          { "key": "level", "value": { "stringValue": to_string(.level) ?? "" } },
+          { "key": "event_type", "value": { "stringValue": event_type } },
+          { "key": "operation_id", "value": { "stringValue": operation_id } },
+          { "key": "traceID", "value": { "stringValue": trace_id } },
+          { "key": "templateID", "value": { "stringValue": template_id } },
+          { "key": "stacktrace", "value": { "stringValue": stacktrace } }
+        ]
+      }]
+    }]
+  }]
+}
+'''
+
+# Enable debugging of logs to the console
+# [sinks.console_loki]
+# type = "console"
+# inputs = ["remove_internal"]
+# encoding.codec = "json"
+
+[sinks.local_otel_logs]
+type = "opentelemetry"
+inputs = [ "to_otel_logs" ]
+healthcheck.enabled = true
+
+[sinks.local_otel_logs.protocol]
+type = "http"
+uri = "http://127.0.0.1:4319/v1/logs"
+method = "post"
+
+[sinks.local_otel_logs.protocol.encoding]
+codec = "json"
+
+[sinks.local_otel_logs.protocol.framing]
+method = "newline_delimited"
+
+[sinks.local_otel_logs.protocol.request.headers]
+content-type = "application/json"
+
+        EOH
+      }
+    }
+  }
+}

--- a/nomad/deploy/loki-deploy.hcl
+++ b/nomad/deploy/loki-deploy.hcl
@@ -1,0 +1,142 @@
+job "loki" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  type        = "service"
+  node_pool = "api"
+
+  priority = 75
+
+  group "loki-service" {
+    network {
+      port "loki" {
+        static = "3100"
+      }
+    }
+
+    service {
+      name = "loki"
+      port = "loki"
+
+      check {
+        type     = "http"
+        path     = "/ready"
+        interval = "20s"
+        timeout  = "2s"
+        port     = "3100"
+      }
+    }
+
+    task "loki" {
+      driver = "docker"
+
+      config {
+        network_mode = "host"
+        image = "artifactory.aic.aws.zoomdev.us/zoom-docker-virtual/grafana/loki:2.9.8"
+        auth_soft_fail = true
+        args = [
+          "-config.file",
+          "local/loki-config.yml",
+        ]
+      }
+
+      resources {
+        memory_max = 2048
+        memory     = 1024
+        cpu        = 500
+      }
+
+      template {
+        data = <<EOF
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: "warn"
+  grpc_server_max_recv_msg_size: 104857600  # 100 Mb
+  grpc_server_max_send_msg_size: 104857600  # 100 Mb
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+storage_config:
+  aws:
+    s3: "s3://us-west-2/e2b-dev-loki-storage-269562551342"
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-shipper-active
+    cache_location: /loki/tsdb-shipper-cache
+    cache_ttl: 1h
+    shared_store: aws
+
+chunk_store_config:
+  chunk_cache_config:
+    embedded_cache:
+      enabled: true
+      max_size_mb: 2048
+      ttl: 30m
+
+query_range:
+  align_queries_with_step: true
+  cache_results: true
+  max_retries: 2
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 2048
+        ttl: 30m
+
+ingester_client:
+  grpc_client_config:
+    max_recv_msg_size: 104857600  # 100 Mb
+    max_send_msg_size: 104857600  # 100 Mb
+
+ingester:
+  chunk_idle_period: 10m
+  chunk_encoding: snappy
+  max_chunk_age: 15m
+  chunk_target_size: 1048576  # 1MB
+  wal:
+    dir: /loki/wal
+    enabled: false
+    flush_on_shutdown: true
+
+schema_config:
+ configs:
+    - from: 2024-03-05
+      store: tsdb
+      object_store: aws
+      schema: v12
+      index:
+        prefix: loki_index_
+        period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  shared_store: aws
+
+# The bucket lifecycle policy should be set to delete objects after MORE than the specified retention period
+limits_config:
+  retention_period: 168h
+  ingestion_rate_mb: 100
+  ingestion_burst_size_mb: 500
+  per_stream_rate_limit: "80MB"
+  per_stream_rate_limit_burst: "240MB"
+  max_streams_per_user: 0
+  split_queries_by_interval: 30m
+  max_global_streams_per_user: 0
+  unordered_writes: true
+  reject_old_samples_max_age: 168h
+EOF
+
+        destination = "local/loki-config.yml"
+      }
+    }
+  }
+}

--- a/nomad/deploy/orchestrator-deploy.hcl
+++ b/nomad/deploy/orchestrator-deploy.hcl
@@ -1,0 +1,73 @@
+job "orchestrator" {
+  type = "system"
+  datacenters = ["us-west-2a", "us-west-2b"]
+
+  priority = 90
+
+  group "client-orchestrator" {
+    network {
+      port "orchestrator" {
+        static = "5008"
+      }
+    }
+
+    service {
+      name = "orchestrator"
+      port = "orchestrator"
+
+      check {
+        type         = "grpc"
+        name         = "health"
+        interval     = "20s"
+        timeout      = "5s"
+        grpc_use_tls = false
+        port         = "orchestrator"
+      }
+    }
+
+    task "start" {
+      driver = "raw_exec"
+
+      env {
+        NODE_ID                      = "$${node.unique.id}"
+        OTEL_TRACING_PRINT           = false
+        LOGS_COLLECTOR_ADDRESS       = "http://localhost:30006"
+        LOGS_COLLECTOR_PUBLIC_IP     = "http://$${attr.unique.network.ip-address}:30006"
+        LOGS_COLLECTOR_FIREWALL_IP   = "$${attr.unique.network.ip-address}"
+        ENVIRONMENT                  = "dev"
+        TEMPLATE_BUCKET_NAME         = "e2b-dev-fc-template-269562551342"
+        OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:4317"
+        AWS_ENABLED                  = true
+        TEMPLATE_AWS_BUCKET_NAME     = "e2b-dev-fc-template-269562551342"
+        AWS_REGION                   = "us-west-2"
+        USE_FIRECRACKER_NATIVE_DIFF  = true
+        STORAGE_PROVIDER             = "AWSBucket"
+        ARTIFACTS_REGISTRY_PROVIDER  = "AWS_ECR"
+        ORCHESTRATOR_SERVICES        = "orchestrator"
+        CONSUL_HTTP_ADDR             = "https://127.0.0.1:8501"
+        CONSUL_CACERT                = "/opt/consul/tls/ca/ca.pem"
+        CONSUL_CLIENT_CERT           = "/opt/consul/tls/cert.pem"
+        CONSUL_CLIENT_KEY            = "/opt/consul/tls/key.pem"
+      }
+
+      template {
+        data = <<EOH
+CONSUL_TOKEN={{ file "/opt/e2b/secrets/consul_http_token" }}
+EOH
+        destination = "secrets/secrets.env"
+        env         = true
+        change_mode = "restart"
+        perms       = "400"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = ["-c", " chmod +x local/orchestrator && local/orchestrator --port 5008 --proxy-port 5007"]
+      }
+
+      artifact {
+        source = "s3://software-e2b-dev-us-west-2-269562551342.s3.us-west-2.amazonaws.com/orchestrator"
+      }
+    }
+  }
+}

--- a/nomad/deploy/otel-collector-deploy.hcl
+++ b/nomad/deploy/otel-collector-deploy.hcl
@@ -1,0 +1,355 @@
+job "otel-collector" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  type        = "system"
+  node_pool   = "all"
+
+  priority = 95
+
+  group "otel-collector" {
+    network {
+      port "health" {
+        to = 13133
+      }
+
+      port "metrics" {
+        to = 8888
+      }
+
+      # Receivers
+      port "grpc" {
+        to = 4317
+      }
+
+      port "http" {
+        to = 4318
+      }
+
+      port "sandbox_http" {
+        to = 4319
+      }
+    }
+
+    service {
+      name = "otel-collector"
+      port = "grpc"
+      tags = ["grpc"]
+
+      check {
+        type     = "http"
+        name     = "health"
+        path     = "/health"
+        interval = "20s"
+        timeout  = "5s"
+        port     = 13133
+      }
+    }
+
+    task "start-collector" {
+      driver = "docker"
+
+      config {
+        network_mode = "host"
+        image        = "artifactory.aic.aws.zoomdev.us/zoom-docker-virtual/otel/opentelemetry-collector-contrib:0.130.0"
+        auth_soft_fail = true
+        volumes = [
+          "local/config:/config",
+        ]
+        args = [
+          "--config=local/config/otel-collector-config.yaml",
+          "--feature-gates=pkg.translator.prometheus.NormalizeName",
+        ]
+
+        ports = [
+          "metrics",
+          "grpc",
+          "health",
+          "http",
+          "sandbox_http",
+        ]
+      }
+
+      resources {
+        memory_max = 4096
+        memory = 1024
+        cpu    = 256
+      }
+
+      # Nomad agent (root) reads host-only files and renders them into the
+      # task-local config dir. The collector container (non-root UID 10001)
+      # reads from /config (= alloc/local/config), bypassing host permission
+      # restrictions on /opt/nomad/tls/*.pem (0600 nomad:nomad) and
+      # /opt/e2b/secrets/* (0600 root:root, dir 0700).
+      template {
+        destination = "local/config/nomad-ca.pem"
+        data        = "{{ file \"/opt/nomad/tls/ca.pem\" }}"
+        change_mode = "restart"
+        perms       = "444"
+      }
+
+      template {
+        destination = "local/config/nomad-cert.pem"
+        data        = "{{ file \"/opt/nomad/tls/cert.pem\" }}"
+        change_mode = "restart"
+        perms       = "444"
+      }
+
+      template {
+        destination = "local/config/nomad-key.pem"
+        data        = "{{ file \"/opt/nomad/tls/key.pem\" }}"
+        change_mode = "restart"
+        perms       = "444"
+      }
+
+      template {
+        data = <<EOF
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 100
+        read_buffer_size: 10943040
+        max_concurrent_streams: 200
+        write_buffer_size: 10943040
+      http:
+        endpoint: 0.0.0.0:4318
+  otlp/sandbox:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4319
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: nomad
+          scrape_interval: 15s
+          scrape_timeout: 5s
+          metrics_path: '/v1/metrics'
+          # Nomad 4646 HTTPS + mTLS (see run-nomad.sh: http=true, verify_https_client=true)
+          # Certs/token are rendered by Nomad template into the task-local
+          # config directory (`/config`, UID 10001 readable) — host paths are
+          # root-owned 0600 and not accessible to the collector container.
+          scheme: https
+          tls_config:
+            ca_file: /config/nomad-ca.pem
+            cert_file: /config/nomad-cert.pem
+            key_file: /config/nomad-key.pem
+            insecure_skip_verify: true
+          authorization:
+            type: Bearer
+            credentials: '{{ file "/opt/e2b/secrets/nomad_acl_token" }}'
+          static_configs:
+            - targets: ['localhost:4646']
+          params:
+            format: ['prometheus']
+        - job_name: e2b-hugepages
+          scrape_interval: 15s
+          scrape_timeout: 5s
+          metrics_path: /metrics
+          static_configs:
+            - targets: ['127.0.0.1:9108']
+
+processors:
+  batch:
+    timeout: 15s
+    send_batch_size: 1500
+    send_batch_max_size: 2000
+
+
+  # keep only metrics that are used
+  filter/otlp:
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
+    metrics:
+      include:
+        match_type: regexp
+        metric_names:
+          - "orchestrator.*"
+          - "template.*"
+          - "api.*"
+          - "client_proxy.*"
+          - "e2b\\.sandbox\\..*"      # per-sandbox cpu/ram gauges
+          - "http\\..*"                  # api HTTP middleware histograms
+          - "rpc\\..*"                   # otelgrpc client/server histograms
+          - "otelcol_.*"                   # collector self-metrics
+
+
+  filter/prometheus:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - "up"
+          - "nomad_client_host_cpu_total_percent"
+          - "nomad_client_host_cpu_idle"
+          - "nomad_client_host_disk_available"
+          - "nomad_client_host_disk_size"
+          - "nomad_client_host_memory_available"
+          - "nomad_client_host_memory_total"
+          - "nomad_client_allocs_memory_usage"
+          - "nomad_client_allocs_memory_allocated"
+          - "nomad_client_allocs_cpu_total_percent"
+          - "nomad_client_allocs_cpu_allocated"
+          - "e2b_host_hugepage_size_bytes"
+          - "e2b_host_hugetlb_bytes"
+          - "e2b_host_mem_available_bytes"
+          - "e2b_host_hugepages_total"
+          - "e2b_host_hugepages_free"
+          - "e2b_host_hugepages_reserved"
+          - "e2b_host_hugepages_surplus"
+          - "e2b_host_hugepages_persistent_configured"
+          - "e2b_host_hugepages_overcommit_configured"
+          - "e2b_host_hugepages_total_bytes"
+          - "e2b_host_hugepages_free_bytes"
+          - "e2b_host_hugepages_reserved_bytes"
+          - "e2b_host_hugepages_surplus_bytes"
+          - "e2b_host_hugepages_free_ratio"
+          - "e2b_host_hugepages_reserved_ratio"
+          - "e2b_host_vmstat_pgfault_total"
+          - "e2b_host_vmstat_pgfault"
+          - "e2b_host_vmstat_pgmajfault_total"
+          - "e2b_host_vmstat_pgmajfault"
+          - "e2b_host_hugetlb_buddy_alloc_success_total"
+          - "e2b_host_hugetlb_buddy_alloc_success"
+          - "e2b_host_hugetlb_buddy_alloc_fail_total"
+          - "e2b_host_hugetlb_buddy_alloc_fail"
+          - "e2b_host_memory_pressure_some_avg10"
+          - "e2b_host_memory_pressure_some_avg60"
+          - "e2b_host_memory_pressure_some_avg300"
+          - "e2b_host_memory_pressure_some_total"
+          - "e2b_host_memory_pressure_some"
+          - "e2b_host_memory_pressure_full_avg10"
+          - "e2b_host_memory_pressure_full_avg60"
+          - "e2b_host_memory_pressure_full_avg300"
+          - "e2b_host_memory_pressure_full_total"
+          - "e2b_host_memory_pressure_full"
+          - "e2b_host_hugepages_free_sandbox_slots"
+          - "e2b_host_hugepages_total_sandbox_slots"
+          - "e2b_host_hugepages_reserved_sandbox_slots"
+          - "e2b_host_numa_hugepages_total"
+          - "e2b_host_numa_hugepages_free"
+          - "e2b_host_numa_hugepages_surplus"
+
+
+  metricstransform:
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor
+    transforms:
+      - include: "nomad_client_host_cpu_idle"
+        match_type: strict
+        action: update
+        operations:
+          - action: aggregate_labels
+            aggregation_type: sum
+            label_set: [instance, node_id, node_status, node_pool]
+
+  resourcedetection:
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+    detectors: [ec2]
+    override: true
+    ec2:
+      resource_attributes:
+        cloud.provider:
+          enabled: false
+        cloud.platform:
+          enabled: false
+        cloud.account.id:
+          enabled: false
+        cloud.availability_zone:
+          enabled: false
+        cloud.region:
+          enabled: false
+        host.type:
+          enabled: true
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+
+  transform/set-name:
+    metric_statements:
+      - delete_key(datapoint.attributes, "instance")
+      - delete_key(datapoint.attributes, "node_id")
+      - delete_key(datapoint.attributes, "node_scheduling_eligibility")
+      - delete_key(datapoint.attributes, "node_class")
+      - delete_key(datapoint.attributes, "node_status")
+      - delete_key(datapoint.attributes, "service_name")
+      - set(datapoint.attributes["service.instance.id"], resource.attributes["host.name"])
+
+  filter/rpc_duration_only:
+    metrics:
+      include:
+        match_type: regexp
+        # Include info about grpc server endpoint durations - used for monitoring request times
+        metric_names:
+          - "rpc.server.duration.*"
+  resource/remove_instance:
+    attributes:
+      - action: delete
+        key: service.instance.id
+  resource/customer_enrich:
+    attributes:
+      - key: cluster
+        value: ""
+        action: upsert
+  filter/logs_severity:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'severity_number < SEVERITY_NUMBER_INFO'
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+exporters:
+  debug:
+    verbosity: detailed
+  # Customer OTel HTTP endpoint (no auth required)
+  # Use http:// for insecure, https:// for TLS
+  otlphttp/customer:
+    endpoint: ""
+
+service:
+  telemetry:
+    logs:
+      level: warn
+    metrics:
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                protocol: grpc
+                insecure: true
+                endpoint: localhost:4317
+  extensions:
+    - health_check
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [filter/otlp, resourcedetection, resource/customer_enrich, transform/set-name, batch]
+      exporters: [otlphttp/customer]
+    metrics/prometheus:
+      receivers: [prometheus]
+      processors: [filter/prometheus, metricstransform, resourcedetection, resource/customer_enrich, transform/set-name, batch]
+      exporters: [otlphttp/customer]
+    metrics/rpc_only:
+      receivers: [otlp]
+      processors: [filter/rpc_duration_only, resource/remove_instance, resourcedetection, resource/customer_enrich, transform/set-name, batch]
+      exporters: [otlphttp/customer]
+    traces:
+      receivers: [otlp]
+      processors: [resource/customer_enrich, batch]
+      exporters: [otlphttp/customer]
+    logs:
+      receivers: [otlp]
+      processors: [filter/logs_severity, resource/customer_enrich, batch]
+      exporters: [otlphttp/customer]
+    logs/sandbox:
+      receivers: [otlp/sandbox]
+      processors: [resource/customer_enrich, batch]
+      exporters: [otlphttp/customer]
+EOF
+
+        destination = "local/config/otel-collector-config.yaml"
+      }
+    }
+  }
+}

--- a/nomad/deploy/redis-deploy.hcl
+++ b/nomad/deploy/redis-deploy.hcl
@@ -1,0 +1,45 @@
+job "redis" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  node_pool = "api"
+  type = "service"
+  priority = 95
+
+  group "redis" {
+    network {
+      port "redis" {
+        static = "6379"
+      }
+    }
+
+    service {
+      name = "redis"
+      port = "redis"
+
+      check {
+        type    = "tcp"
+        name    = "health"
+        interval = "10s"
+        timeout = "2s"
+        port    = "redis"
+      }
+    }
+
+    task "start" {
+      driver = "docker"
+
+      resources {
+        memory_max = 4096
+        memory    = 2048
+        cpu      = 1000
+      }
+
+      config {
+        network_mode = "host"
+        image        = "artifactory.aic.aws.zoomdev.us/zoom-docker-virtual/redis:7.4.2-alpine"
+        ports        = ["redis"]
+        args = []
+        auth_soft_fail = true
+      }
+    }
+  }
+}

--- a/nomad/deploy/template-manager-deploy.hcl
+++ b/nomad/deploy/template-manager-deploy.hcl
@@ -1,0 +1,72 @@
+job "template-manager" {
+  datacenters = ["us-west-2a", "us-west-2b"]
+  node_pool  = "default"
+  priority = 70
+
+  group "template-manager" {
+    network {
+      port "template-manager" {
+        static = "5009"
+      }
+    }
+    service {
+      name = "template-manager"
+      port = "template-manager"
+
+      check {
+        type         = "grpc"
+        name         = "health"
+        interval     = "20s"
+        timeout      = "5s"
+        grpc_use_tls = false
+        port         = "template-manager"
+      }
+    }
+
+    task "start" {
+      driver = "raw_exec"
+
+      resources {
+        memory     = 1024
+        cpu        = 256
+      }
+
+      env {
+        NODE_ID                      = "$${node.unique.name}"
+        AWS_ACCOUNT_ID               = "269562551342"
+        STORAGE_PROVIDER             = "AWSBucket"
+        ARTIFACTS_REGISTRY_PROVIDER  = "AWS_ECR"
+        AWS_DOCKER_REPOSITORY_NAME   = "e2bdev/base"
+        AWS_REGION                   = "us-west-2"
+        AWS_ECR_REPOSITORY           = "e2bdev/base"
+        OTEL_TRACING_PRINT           = false
+        ENVIRONMENT                  = "dev"
+        TEMPLATE_AWS_BUCKET_NAME     = "e2b-dev-fc-template-269562551342"
+        TEMPLATE_BUCKET_NAME         = "e2b-dev-fc-template-269562551342"
+        BUILD_CONTEXT_BUCKET_NAME    = "e2b-dev-docker-contexts-269562551342"
+        OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:4317"
+        LOGS_COLLECTOR_ADDRESS       = "http://localhost:30006"
+        ORCHESTRATOR_SERVICES        = "template-manager"
+      }
+
+      template {
+        data = <<EOH
+CONSUL_TOKEN={{ file "/opt/e2b/secrets/consul_http_token" }}
+EOH
+        destination = "secrets/secrets.env"
+        env         = true
+        change_mode = "restart"
+        perms       = "400"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = ["-c", " chmod +x local/template-manager && local/template-manager --port 5009  --proxy-port 15007"]
+      }
+
+      artifact {
+        source      = "s3://software-e2b-dev-us-west-2-269562551342.s3.us-west-2.amazonaws.com/template-manager"
+      }
+    }
+  }
+}

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,8 +1,8 @@
 ARG JFROG_DOCKER_REGISTRY=artifactory.aic.aws.zoomdev.us/zoom-docker-virtual
-FROM ${JFROG_DOCKER_REGISTRY}/golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine3.20 AS builder
 
-ARG JFROG_ARTIFACTORY_URL=https://artifactory.aic.aws.zoomdev.us/artifactory
-ENV GOPROXY=${JFROG_ARTIFACTORY_URL}/api/go/zoom-go-virtual
+ARG JFROG_ARTIFACTORY_URL=unused
+ENV GOPROXY=https://proxy.golang.org,direct
 
 RUN apk add --no-cache make
 
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build make build
 
 RUN chmod +x /build/api/bin/api
 
-FROM ${JFROG_DOCKER_REGISTRY}/alpine:3.20
+FROM alpine:3.20
 
 # Install Docker CLI (communicates with host Docker daemon via mounted docker.sock)
 RUN apk add --no-cache docker-cli

--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
@@ -118,7 +119,13 @@ func (c *InstanceCache) reconcileRedis(ctx context.Context, instances []*Instanc
 
 		redisItem, err := c.redisStore.Get(ctx, *instance.TeamID, instance.Instance.SandboxID)
 		if err != nil {
-			orphans = append(orphans, instance)
+			if errors.Is(err, ErrRedisSandboxNotFound) || errors.Is(err, redis.Nil) {
+				orphans = append(orphans, instance)
+			} else {
+				zap.L().Warn("Redis error during reconcile, skipping orphan check",
+					zap.Error(err),
+					zap.String("sandbox_id", instance.Instance.SandboxID))
+			}
 			continue
 		}
 

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/cache/instance"
 	"github.com/e2b-dev/infra/packages/api/internal/node"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -343,6 +345,29 @@ func (o *Orchestrator) getInsertInstanceFunction(parentCtx context.Context, time
 			node.RamUsage.Add(info.RamMB)
 
 			o.dns.Add(ctx, info.Instance.SandboxID, node.Info.IPAddress)
+
+			// Write SandboxInfo JSON to Redis for client-proxy catalog resolution
+			if o.redisClient != nil {
+				maxLengthHours := int64(info.MaxInstanceLength.Hours())
+				if maxLengthHours < 1 {
+					maxLengthHours = 1
+				}
+				catalogEntry := map[string]interface{}{
+					"orchestrator_id":             node.Info.ID,
+					"execution_id":                info.ExecutionID,
+					"sandbox_started_at":          info.StartTime,
+					"sandbox_max_length_in_hours": maxLengthHours,
+				}
+				catalogJSON, jsonErr := json.Marshal(catalogEntry)
+				if jsonErr == nil {
+					catalogKey := fmt.Sprintf("sandbox.dns.%s", info.Instance.SandboxID)
+					ttl := info.MaxInstanceLength + time.Minute
+					if setErr := o.redisClient.Set(ctx, catalogKey, string(catalogJSON), ttl).Err(); setErr != nil {
+						zap.L().Error("failed to write sandbox catalog to Redis",
+							zap.Error(setErr), logger.WithSandboxID(info.Instance.SandboxID))
+					}
+				}
+			}
 		}
 
 		if info.AutoPause.Load() {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -245,6 +245,12 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 
 		o.dns.Remove(ctx, info.Instance.SandboxID, node.Info.IPAddress)
 
+		// Remove catalog entry
+		if o.redisClient != nil {
+			catalogKey := fmt.Sprintf("sandbox:catalog:%s", info.Instance.SandboxID)
+			o.redisClient.Del(ctx, catalogKey)
+		}
+
 		if node.Client == nil {
 			zap.L().Error("client for node not found", zap.String("node_id", info.Instance.ClientID))
 
@@ -354,13 +360,14 @@ func (o *Orchestrator) getInsertInstanceFunction(parentCtx context.Context, time
 				}
 				catalogEntry := map[string]interface{}{
 					"orchestrator_id":             node.Info.ID,
+					"orchestrator_ip":             node.Info.IPAddress,
 					"execution_id":                info.ExecutionID,
 					"sandbox_started_at":          info.StartTime,
 					"sandbox_max_length_in_hours": maxLengthHours,
 				}
 				catalogJSON, jsonErr := json.Marshal(catalogEntry)
 				if jsonErr == nil {
-					catalogKey := fmt.Sprintf("sandbox.dns.%s", info.Instance.SandboxID)
+					catalogKey := fmt.Sprintf("sandbox:catalog:%s", info.Instance.SandboxID)
 					ttl := info.MaxInstanceLength + time.Minute
 					if setErr := o.redisClient.Set(ctx, catalogKey, string(catalogJSON), ttl).Err(); setErr != nil {
 						zap.L().Error("failed to write sandbox catalog to Redis",

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -40,6 +40,7 @@ type Orchestrator struct {
 	tracer              trace.Tracer
 	analytics           *analyticscollector.Analytics
 	dns                 *dns.DNS
+	redisClient         redis.UniversalClient
 	dbClient            *db.DB
 	tel                 *telemetry.Client
 	metricsRegistration metric.Registration
@@ -79,6 +80,7 @@ func New(
 		tracer:      tracer,
 		nodes:       smap.New[*Node](),
 		dns:         dnsServer,
+		redisClient: redisClient,
 		dbClient:    dbClient,
 		tel:         tel,
 	}

--- a/packages/client-proxy/Dockerfile
+++ b/packages/client-proxy/Dockerfile
@@ -1,8 +1,8 @@
 ARG JFROG_DOCKER_REGISTRY=artifactory.aic.aws.zoomdev.us/zoom-docker-virtual
-FROM ${JFROG_DOCKER_REGISTRY}/golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine3.20 AS builder
 
 ARG JFROG_ARTIFACTORY_URL=https://artifactory.aic.aws.zoomdev.us/artifactory
-ENV GOPROXY=${JFROG_ARTIFACTORY_URL}/api/go/zoom-go-virtual
+ENV GOPROXY=https://proxy.golang.org,direct
 
 RUN apk add --no-cache make
 
@@ -25,7 +25,7 @@ ARG COMMIT_SHA
 RUN --mount=type=cache,target=/root/.cache/go-build make build COMMIT_SHA=${COMMIT_SHA}
 RUN chmod +x /build/proxy/bin/client-proxy
 
-FROM ${JFROG_DOCKER_REGISTRY}/alpine:3.17
+FROM alpine:3.17
 
 COPY --from=builder /build/proxy/bin/client-proxy .
 

--- a/packages/client-proxy/internal/edge/sandboxes/catalog.go
+++ b/packages/client-proxy/internal/edge/sandboxes/catalog.go
@@ -7,6 +7,7 @@ import (
 
 type SandboxInfo struct {
 	OrchestratorId string `json:"orchestrator_id"`
+	OrchestratorIP string `json:"orchestrator_ip"`
 	ExecutionId    string `json:"execution_id"`
 
 	SandboxStartedAt        time.Time `json:"sandbox_started_at"`          // when sandbox was started

--- a/packages/client-proxy/internal/edge/sandboxes/catalog_redis.go
+++ b/packages/client-proxy/internal/edge/sandboxes/catalog_redis.go
@@ -154,7 +154,7 @@ func (c *RedisSandboxCatalog) getCatalogKey(sandboxId string) string {
 	zap.L().Debug("getCatalogKey method called", 
 		zap.String("input_sandboxId", sandboxId))
 	
-	key := fmt.Sprintf("sandbox.dns.%s", sandboxId)
+	key := fmt.Sprintf("sandbox:catalog:%s", sandboxId)
 	
 	zap.L().Debug("getCatalogKey method result", 
 		zap.String("input_sandboxId", sandboxId),

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -95,6 +95,13 @@ func catalogResolution(sandboxId string, catalog sandboxes.SandboxesCatalog, orc
 
 	o, ok := orchestrators.GetOrchestrator(s.OrchestratorId)
 	if !ok {
+		// Fallback: catalog stores Nomad node ID, pool is keyed by ServiceInstanceId.
+		// Match by NodeID field (O(N) where N=number of orchestrator nodes, typically 1-5).
+		for _, node := range orchestrators.GetOrchestrators() {
+			if node.NodeID == s.OrchestratorId {
+				return node.Ip, nil
+			}
+		}
 		return "", errors.New("orchestrator not found")
 	}
 

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -93,19 +93,19 @@ func catalogResolution(sandboxId string, catalog sandboxes.SandboxesCatalog, orc
 		return "", fmt.Errorf("failed to get sandbox from catalog: %w", err)
 	}
 
-	o, ok := orchestrators.GetOrchestrator(s.OrchestratorId)
-	if !ok {
-		// Fallback: catalog stores Nomad node ID, pool is keyed by ServiceInstanceId.
-		// Match by NodeID field (O(N) where N=number of orchestrator nodes, typically 1-5).
-		for _, node := range orchestrators.GetOrchestrators() {
-			if node.NodeID == s.OrchestratorId {
-				return node.Ip, nil
-			}
-		}
-		return "", errors.New("orchestrator not found")
+	// Use OrchestratorIP directly from catalog (aligned with upstream design)
+	if s.OrchestratorIP != "" {
+		return s.OrchestratorIP, nil
 	}
 
-	return o.Ip, nil
+	// Fallback: match by NodeID for catalog entries without IP (e.g. created before this fix)
+	for _, node := range orchestrators.GetOrchestrators() {
+		if node.NodeID == s.OrchestratorId {
+			return node.Ip, nil
+		}
+	}
+
+	return "", errors.New("orchestrator not found")
 }
 
 func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port uint, catalog sandboxes.SandboxesCatalog, orchestrators *orchestratorspool.OrchestratorsPool, useCatalogResolution bool, useDnsResolution bool) (*reverseproxy.Proxy, error) {

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
 	"github.com/google/uuid"
+	"crypto/tls"
 	"github.com/redis/go-redis/v9"
 	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
@@ -124,11 +125,11 @@ func run() int {
 	var catalog sandboxes.SandboxesCatalog
 
 	if redisClusterUrl := os.Getenv("REDIS_CLUSTER_URL"); redisClusterUrl != "" {
-		redisClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{redisClusterUrl}, MinIdleConns: 1})
+		redisClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{redisClusterUrl}, MinIdleConns: 1, TLSConfig: &tls.Config{}})
 		redisSync := redsync.New(goredis.NewPool(redisClient))
 		catalog = sandboxes.NewRedisSandboxesCatalog(ctx, tracer, redisClient, redisSync)
 	} else if redisUrl := os.Getenv("REDIS_URL"); redisUrl != "" {
-		redisClient := redis.NewClient(&redis.Options{Addr: redisUrl, MinIdleConns: 1})
+		redisClient := redis.NewClient(&redis.Options{Addr: redisUrl, MinIdleConns: 1, TLSConfig: &tls.Config{}})
 		redisSync := redsync.New(goredis.NewPool(redisClient))
 		catalog = sandboxes.NewRedisSandboxesCatalog(ctx, tracer, redisClient, redisSync)
 	} else {


### PR DESCRIPTION
## Summary

Fixes 3 remaining issues in the API horizontal scaling implementation (Jeff's commits `fc3e13f`→`17aaf96`) that prevent client-proxy from correctly routing sandbox traffic in a multi-instance deployment.

## Why These Fixes Are Needed

Jeff's code solved the core HA problems (Redis state storage, instant cross-instance visibility, reservation Lua script). However, we discovered through live 2-node testing that:

1. **Client-proxy catalog resolution was silently disabled** — env var name mismatch (`USE_PROXY_CATALOG_RESOLUTION` in HCL vs `USE_CATALOG_RESOLUTION` in Go code). Confirmed via container log: `WARN: Skipping proxy catalog resolution, using just DNS resolution instead`.

2. **No catalog data written to Redis** — the API insert hook didn't write the `sandbox:catalog:{id}` entry that client-proxy needs for routing. Without it, catalog resolution has nothing to read.

3. **Orchestrator ID format mismatch** — even if catalog data existed, Jeff's code wrote Nomad node short ID (`12fb8e92`) as `orchestrator_id`, but client-proxy's pool is keyed by `ServiceInstanceId` (random UUID). The lookup always failed.

4. **Client-proxy Redis missing TLS** — ElastiCache Serverless requires TLS. Client-proxy's Redis client had no `TLSConfig`, so it couldn't actually connect to read catalog data.

5. **Orphan misdetection during Redis blip** — `reconcileRedis()` treated ALL Redis errors as "sandbox not found" → killed running sandboxes during Redis connectivity issues.

## Design Decisions (Aligned with Upstream)

We referenced the upstream E2B (`github.com/e2b-dev/infra` main branch) for design guidance:

| Decision | Upstream approach | What we did |
|----------|------------------|-------------|
| Catalog Redis key | `sandbox:catalog:{id}` (independent from DNS) | Same — no collision with DNS's `sandbox.dns.{id}` key |
| Catalog content | JSON with `orchestrator_ip` field | Same — store IP directly for routing |
| Routing method | `return s.OrchestratorIP` (direct, no pool lookup) | Same — O(1), no pool ID format issues |
| DNS server | Removed entirely (PR #2636) | Kept as fallback (less invasive) |

## Changes (10 files, +66 -16)

| File | Change |
|------|--------|
| `nomad/origin/edge.hcl` | `USE_PROXY_CATALOG_RESOLUTION` → `USE_CATALOG_RESOLUTION` |
| `packages/api/internal/orchestrator/cache.go` | Write `sandbox:catalog:{id}` JSON (with `orchestrator_ip`) on sandbox create; delete on sandbox kill |
| `packages/api/internal/orchestrator/orchestrator.go` | Add `redisClient` field to struct |
| `packages/api/internal/cache/instance/sync.go` | Distinguish `ErrRedisSandboxNotFound` from connection errors in orphan detection |
| `packages/client-proxy/internal/edge/sandboxes/catalog.go` | Add `OrchestratorIP` field to `SandboxInfo` struct |
| `packages/client-proxy/internal/edge/sandboxes/catalog_redis.go` | Key prefix `sandbox.dns.` → `sandbox:catalog:` |
| `packages/client-proxy/internal/proxy/proxy.go` | `catalogResolution`: use `OrchestratorIP` directly; NodeID scan fallback for old entries |
| `packages/client-proxy/main.go` | Add `TLSConfig: &tls.Config{}` to Redis clients |
| `packages/api/Dockerfile` | Remove JFrog mirror dependency (use public registries) |
| `packages/client-proxy/Dockerfile` | Remove JFrog mirror dependency (use public registries) |

## Test Results (2-node deployment, ALB, SANDBOX_STORAGE_BACKEND=redis)

| Test | Result |
|------|--------|
| API Health (both nodes) | ✅ |
| Catalog key `sandbox:catalog:{id}` written with `orchestrator_ip` | ✅ |
| No key collision with DNS (`sandbox.dns.{id}` separate) | ✅ |
| Client-proxy: no "Skipping catalog" or "orchestrator not found" warnings | ✅ |
| Cross-instance instant visibility (create on A, list on B immediately) | ✅ |
| Cross-instance kill (204) | ✅ |
| SDK create_kill (through ALB) | ✅ |
| SDK commands (ALB → client-proxy → catalog → orchestrator → envd) | ✅ |
| SDK filesystem (file read/write through envd) | ✅ |
| SDK connect_existing (reconnect to sandbox) | ✅ |
| SDK keepalive / set_timeout | ✅ |
| Redis SG block → sandbox survives (orphan fix verified) | ✅ |

## Dockerfile Note

Both Dockerfiles replace JFrog Artifactory references with public registries (`golang:1.24-alpine3.20`, `alpine:3.20`, `proxy.golang.org`). This is necessary for environments without access to `artifactory.aic.aws.zoomdev.us`. Production deployments using JFrog should revert these lines.

## Known Limitations

- Catalog key cleanup on sandbox kill may be delayed (TTL provides eventual cleanup within `MaxInstanceLength + 1 min`)
- DNS server still writes `sandbox.dns.{id}` with msgpack format; DNS fallback path works via TinyLFU local cache but will fail if cache evicts — catalog resolution (primary path) eliminates this concern